### PR TITLE
Fix svelte compiler warning

### DIFF
--- a/src/InfiniteLoading.svelte
+++ b/src/InfiniteLoading.svelte
@@ -1,10 +1,5 @@
 <script context="module">
-	const STATUS = {
-		READY:    0,
-		LOADING:  1,
-		COMPLETE: 2,
-		ERROR:    3,
-	};
+
 	const THROTTLE_LIMIT = 50;
 	const LOOP_CHECK_TIMEOUT = 1000;
 	const LOOP_CHECK_MAX_CALLS = 10;
@@ -151,6 +146,13 @@
 	import Spinner from './Spinner.svelte';
 
 	const dispatch = createEventDispatcher();
+
+	const STATUS = {
+		READY:    0,
+		LOADING:  1,
+		COMPLETE: 2,
+		ERROR:    3,
+	};
 
 	export let distance = 100;
 	export let spinner = 'default';


### PR DESCRIPTION
When compiling I get the following warning. The fix is rather trivial, I just moved the `const STATUS` definition to the regular script section (since it is not referenced in the module sectoin). 
```
(!) Plugin svelte: "STATUS" is declared in a module script and will not be reactive
node_modules/svelte-infinite-loading/src/InfiniteLoading.svelte
165:   let scrollParent;
166: 
167:   $: showSpinner = status === STATUS.LOADING;
                                   ^
168:   $: showError = status === STATUS.ERROR;
169:   $: showNoResults = status === STATUS.COMPLETE && isFirstLoad;
node_modules/svelte-infinite-loading/src/InfiniteLoading.svelte
166: 
167:   $: showSpinner = status === STATUS.LOADING;
168:   $: showError = status === STATUS.ERROR;
                                 ^
169:   $: showNoResults = status === STATUS.COMPLETE && isFirstLoad;
170:   $: showNoMore = status === STATUS.COMPLETE && !isFirstLoad;
node_modules/svelte-infinite-loading/src/InfiniteLoading.svelte
167:   $: showSpinner = status === STATUS.LOADING;
168:   $: showError = status === STATUS.ERROR;
169:   $: showNoResults = status === STATUS.COMPLETE && isFirstLoad;
                                     ^
170:   $: showNoMore = status === STATUS.COMPLETE && !isFirstLoad;
171: 
node_modules/svelte-infinite-loading/src/InfiniteLoading.svelte
168:   $: showError = status === STATUS.ERROR;
169:   $: showNoResults = status === STATUS.COMPLETE && isFirstLoad;
170:   $: showNoMore = status === STATUS.COMPLETE && !isFirstLoad;
                                  ^
171: 
172:   const stateChanger = {
```