### PR TITLE
add the ability to remove the status message when no results / no more to load

### DIFF
--- a/src/InfiniteLoading.svelte
+++ b/src/InfiniteLoading.svelte
@@ -159,6 +159,7 @@
 	export let direction = 'bottom';
 	export let forceUseInfiniteWrapper = false;
 	export let identifier = +new Date();
+	export let hideStatus = false;
 
 	let isFirstLoad = true; // save the current loading whether it is the first loading
 	let status = STATUS.READY;
@@ -168,8 +169,8 @@
 
 	$: showSpinner = status === STATUS.LOADING;
 	$: showError = status === STATUS.ERROR;
-	$: showNoResults = status === STATUS.COMPLETE && isFirstLoad;
-	$: showNoMore = status === STATUS.COMPLETE && !isFirstLoad;
+	$: showNoResults = status === STATUS.COMPLETE && isFirstLoad && !hideStatus;
+	$: showNoMore = status === STATUS.COMPLETE && !isFirstLoad && !hideStatus;
 
 	const stateChanger = {
 		loaded: async () => {


### PR DESCRIPTION
Need the ability to hide the status text which gets rendered when everything is loaded or no results were found.

IE:
`<InfiniteLoading on:infinite={loadingHandler} hideStatus={true} />`